### PR TITLE
raise aeson bound to allow 1.5

### DIFF
--- a/libnix.cabal
+++ b/libnix.cabal
@@ -28,7 +28,7 @@ library
                      , Foreign.Nix.Shellout.Types
   other-modules:       Foreign.Nix.Shellout.Helpers
   build-depends:       base >=4.9 && <5
-                     , aeson >=1.0.0.0 && <1.5.0.0
+                     , aeson >=1.0.0.0 && <1.6.0.0
                      , errors >=2.2.0 && <2.4.0
                      , filepath
                      , protolude ==0.3.*


### PR DESCRIPTION
Test result on my fork: https://github.com/chris-martin/libnix-haskell/runs/2061760941?check_suite_focus=true

